### PR TITLE
.gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### JPA Buddy
+.jpb/
+
 ### STS ###
 .apt_generated
 .classpath


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편하게 해주는
jpa buddy 라는 플러그인이 있는데,
intellij preference 에서 jpa buddy 설정을 바꾸면
이를 별도 숨김 디렉토리에 파일로 저장하는 듯 하다.
이를 확인하고 `.gitignore`에 등록함