### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/hello/helloprojectboard/domain/Article.java
+++ b/src/main/java/com/hello/helloprojectboard/domain/Article.java
@@ -59,8 +59,8 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/hello/helloprojectboard/domain/ArticleComment.java
+++ b/src/main/java/com/hello/helloprojectboard/domain/ArticleComment.java
@@ -47,7 +47,7 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/hello/helloprojectboard/domain/UserAccount.java
+++ b/src/main/java/com/hello/helloprojectboard/domain/UserAccount.java
@@ -44,8 +44,8 @@ public class UserAccount extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
버그는 `equals()`, `hashcode()` 안에서 각 클래스 필드들을 비교하기 위해 접근할 떄, 직접 접근(direct field access)을 했기 때문이다.
jpa 엔티티는 그대로 인스턴스로 만들어 사용하는게 아니라, jpa 구현체 - spring data jpa 에서는 하이버네이트 - 에 의해 프록시 인스턴스로 만들어진다.
때문에 직접 접근을 하면 프록시가 되기 전, 후 인스턴스의 차이로 `equals`, `hashcode` 가 제대로 각 필드를 참조하지 못할 수 있다.
하지만 getter 와 같이 메소드를 이용해 필드에 접근하면 프록시 인스턴스가 된 이후에도 명확하게 각 필드에 접근할 수 있기 때문에
entity 안의 `quals`, `hashcode`를 구현할 때는 getter를 사용해야 한다.